### PR TITLE
New security rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -14,6 +14,9 @@ service cloud.firestore {
     match /users/{userId}/trees/{treeId} {
       allow read, write: if request.auth != null && request.auth.uid == userId
     }
+    match /users/{userId}/proTrees/{proTreeId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId && request.auth.token.plan == "pro"
+    }
     match /{document=**} {
       allow read, write: if false
     }

--- a/rules.test.ts
+++ b/rules.test.ts
@@ -109,3 +109,45 @@ describe("tree deletes", () => {
     await assertSucceeds(deleteDoc(doc(db, "users/userId/trees/treeId")));
   });
 });
+
+describe("pro tree creation", () => {
+  it("cannot be created by unauthenticated users", async () => {
+    const db = testEnv.unauthenticatedContext().firestore();
+    await assertFails(
+      addDoc(collection(db, "users/userId/proTrees"), {
+        this: "is a pro tree"
+      })
+    );
+  });
+
+  it("cannot by created by user without the pro plan", async () => {
+    const db = testEnv.authenticatedContext("userId").firestore();
+    await assertFails(
+      addDoc(collection(db, "users/userId/proTrees"), {
+        this: "is a pro tree"
+      })
+    );
+  });
+
+  it("cannot by created by user with the free plan", async () => {
+    const db = testEnv.authenticatedContext("userId", {
+      plan: "free"
+    }).firestore();
+    await assertFails(
+      addDoc(collection(db, "users/userId/proTrees"), {
+        this: "is a pro tree"
+      })
+    );
+  });
+
+  it("can be created by the actual user with pro plan", async () => {
+    const db = testEnv.authenticatedContext("userId", {
+      plan: "pro"
+    }).firestore();
+    await assertSucceeds(
+      addDoc(collection(db, "users/userId/proTrees"), {
+        this: "is a pro tree"
+      })
+    );
+  });
+});


### PR DESCRIPTION
### Description

Update security rules so that users can read/write to the `users/{userId}/proTrees` collection if the user has the custom claim `{"plan": "pro"}`.